### PR TITLE
New catalog format, dubbed v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ This repository is a set of package definitions for the Dylan programming langua
 data is used by the [pacman](https://github.com/dylan-lang/pacman) library to install
 Dylan packages and their dependencies.
 
-If you would like to add a new library to the catalog just send a pull request. In order
-to test your change, set the `DYLAN_CATALOG` shell variable to the pathname of your local
-catalog and then build and run the `pacman-catalog-test-suite` library to verify that the
-catalog parses correctly.
+If you would like to add a new library to the catalog just send a pull
+request. In order to test your change, set the `DYLAN_CATALOG` shell variable
+to the directory containing your checkout of this repo and then build and run
+the `pacman-catalog-test-suite` library to verify that the catalog parses
+correctly and all dependencies can be resolved.
 
 ```shell
-$ DYLAN_CATALOG=pacman-catalog/tests/catalog.json _build/bin/pacman-catalog-test-suite
+$ DYLAN_CATALOG=pacman-catalog/ _build/bin/pacman-catalog-test-suite
 ```
 
 You're changes will not be "live" until a new release of this repository is created on

--- a/pkg.json
+++ b/pkg.json
@@ -1,7 +1,10 @@
 {
+    "category": "development tools",
+    "contact": "dylan-lang@googlegroups.com",
+    "deps": [ "testworks@2.0" ],
+    "description": "Dylan package manager catalog -- descriptors for all known Dylan packages.",
+    "keywords": ["package"],
     "name": "pacman-catalog",
-    "deps": [
-        "testworks@2.0",
-    ],
-    "location": "https://github.com/dylan-lang/pacman-catalog"
+    "version": "0.3.0",
+    "url": "https://github.com/dylan-lang/pacman-catalog"
 }

--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -8,6 +8,9 @@ end;
 
 define module pacman-catalog-test-suite
   use common-dylan;
-  use pacman, prefix: "pm/";
+  use pacman,
+    import: { catalog, load-all-packages };
+  use %pacman,
+    import: { validate-catalog };
   use testworks;
 end;

--- a/tests/test-suite.dylan
+++ b/tests/test-suite.dylan
@@ -1,15 +1,10 @@
 Module: pacman-catalog-test-suite
 
-// For now just make sure the catalog loads...
-
-define test load-catalog-test ()
-  assert-no-errors(pm/load-catalog());
+define test test-validate-catalog ()
+  assert-no-errors(validate-catalog(catalog()));
+  let packages = load-all-packages(catalog());
+  test-output("loaded %d packages from catalog\n", packages.size);
+  assert-true(packages.size > 0);
 end;
 
-define suite pacman-catalog-suite ()
-  test load-catalog-test;
-end;
-
-begin
-  run-test-application(pacman-catalog-suite);
-end;
+run-test-application();

--- a/v1/an/ap/anaphora
+++ b/v1/an/ap/anaphora
@@ -1,0 +1,13 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Anaphoric constructs",
+  "keywords": [],
+  "name": "anaphora",
+  "releases": [{
+                 "deps": [],
+                 "license": "None",
+                 "url": "https://github.com/dylan-lang/anaphora",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/at/om/atom-language-dylan
+++ b/v1/at/om/atom-language-dylan
@@ -1,0 +1,13 @@
+{
+  "category": "editor support",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Dylan language support for the Atom editor",
+  "keywords": [],
+  "name": "atom-language-dylan",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/atom-language-dylan",
+                 "version": "0.7.3"
+               }]
+}

--- a/v1/ba/se/base64
+++ b/v1/ba/se/base64
@@ -1,0 +1,13 @@
+{
+  "category": "encoding",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Base64 encoding",
+  "keywords": [],
+  "name": "base64",
+  "releases": [{
+                 "deps": [],
+                 "license": "Public Domain",
+                 "url": "https://github.com/dylan-lang/base64",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/bi/na/binary-data
+++ b/v1/bi/na/binary-data
@@ -1,0 +1,13 @@
+{
+  "category": "parsers",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "A DSL for parsing and assembling binary data",
+  "keywords": [],
+  "name": "binary-data",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/binary-data",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/co/ll/collection-extensions
+++ b/v1/co/ll/collection-extensions
@@ -1,0 +1,13 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Collection library",
+  "keywords": [],
+  "name": "collection-extensions",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/collection-extensions",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/co/mm/command-interface
+++ b/v1/co/mm/command-interface
@@ -1,0 +1,13 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Interactive command interface system",
+  "keywords": [],
+  "name": "command-interface",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/command-interface",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/co/mm/command-line-parser
+++ b/v1/co/mm/command-line-parser
@@ -1,0 +1,28 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Command line processing",
+  "keywords": ["cli", "flags"],
+  "name": "command-line-parser",
+  "releases": [{
+                 "deps": ["strings@1.0"],
+                 "license": "opendylan license",
+                 "url": "https://github.com/dylan-lang/command-line-parser",
+                 "version": "1.0.0"
+               }, {
+                 "deps": ["strings@1.0"],
+                 "license": "opendylan license",
+                 "url": "https://github.com/dylan-lang/command-line-parser",
+                 "version": "2.0.0"
+               }, {
+                 "deps": ["strings@1.0"],
+                 "license": "opendylan license",
+                 "url": "https://github.com/dylan-lang/command-line-parser",
+                 "version": "3.0.0"
+               }, {
+                 "deps": ["strings@1.1"],
+                 "license": "opendylan license",
+                 "url": "https://github.com/dylan-lang/command-line-parser",
+                 "version": "3.1.0"
+               }]
+}

--- a/v1/co/nc/concurrency
+++ b/v1/co/nc/concurrency
@@ -1,0 +1,13 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Concurrency utilities",
+  "keywords": [],
+  "name": "concurrency",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-foundry/concurrency",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/dy/la/dylan-emacs-support
+++ b/v1/dy/la/dylan-emacs-support
@@ -1,0 +1,13 @@
+{
+  "category": "editor support",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Emacs mode for indenting and highlighting Dylan code",
+  "keywords": [],
+  "name": "dylan-emacs-support",
+  "releases": [{
+                 "deps": [],
+                 "license": "GPL",
+                 "url": "https://github.com/dylan-lang/dylan-emacs-support",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/dy/la/dylan-tool
+++ b/v1/dy/la/dylan-tool
@@ -1,0 +1,24 @@
+{
+  "category": "language-tools",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Manage Dylan workspaces, packages, and registries",
+  "keywords": ["workspace", "package"],
+  "name": "dylan-tool",
+  "releases": [{
+                 "deps": ["command-line-parser@3.0", "json@1.0", "logging@2.1",
+                          "pacman@0.2.0", "regular-expressions@1.0",
+                          "testworks@2.0", "uncommon-dylan@0.2",
+                          "workspaces@0.2.0"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/dylan-tool",
+                 "version": "0.2.0"
+               }, {
+                 "deps": ["command-line-parser@3.1", "http@1.1", "json@1.0",
+                          "logging@2.1", "pacman@0.3.0",
+                          "regular-expressions@1.0", "testworks@2.0",
+                          "uncommon-dylan@0.2", "workspaces@0.3.0"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/dylan-tool",
+                 "version": "0.3.0"
+               }]
+}

--- a/v1/ha/sh/hash-algorithms
+++ b/v1/ha/sh/hash-algorithms
@@ -1,0 +1,13 @@
+{
+  "category": "cryptography",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Cryptographic hash functions",
+  "keywords": [],
+  "name": "hash-algorithms",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/hash-algorithms",
+                 "version": "1.0.0"
+               }]
+}

--- a/v1/ht/tp/http
+++ b/v1/ht/tp/http
@@ -1,0 +1,43 @@
+{
+  "category": "network",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "HTTP server and client",
+  "keywords": [],
+  "name": "http",
+  "releases": [{
+                 "deps": ["base64", "concurrency", "logging", "meta", "mime",
+                          "serialization", "sphinx-extensions",
+                          "uncommon-dylan", "uri", "xml-parser"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/http",
+                 "version": "0.1.0"
+               }, {
+                 "deps": ["base64", "concurrency", "logging", "meta", "mime",
+                          "serialization", "sphinx-extensions",
+                          "uncommon-dylan", "uri", "xml-parser"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/http",
+                 "version": "0.1.1"
+               }, {
+                 "deps": ["base64@0.1", "concurrency@0.1", "logging@2.1",
+                          "meta@0.1", "mime@0.1", "serialization@0.1",
+                          "sphinx-extensions@0.1", "uri@1.0", "xml-parser@0.1"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/http",
+                 "version": "1.0.0"
+               }, {
+                 "deps": ["base64@0.1", "concurrency@0.1", "logging@2.1",
+                          "meta@0.1", "mime@0.1", "serialization@0.1",
+                          "sphinx-extensions@0.1", "uri@1.0", "xml-parser@0.1"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/http",
+                 "version": "1.0.1"
+               }, {
+                 "deps": ["base64@0.1", "concurrency@0.1", "logging@2.1",
+                          "meta@0.1", "mime@0.1", "serialization@0.1",
+                          "sphinx-extensions@0.1", "uri@1.0", "xml-parser@0.1"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/http",
+                 "version": "1.1.0"
+               }]
+}

--- a/v1/js/on/json
+++ b/v1/js/on/json
@@ -1,0 +1,13 @@
+{
+  "category": "parsers",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "parse and write JSON data format",
+  "keywords": ["workspace", "package"],
+  "name": "json",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/json",
+                 "version": "1.0.0"
+               }]
+}

--- a/v1/li/sp/lisp-to-dylan
+++ b/v1/li/sp/lisp-to-dylan
@@ -1,0 +1,13 @@
+{
+  "category": "development tools",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Convert Common Lisp code to Dylan",
+  "keywords": [],
+  "name": "lisp-to-dylan",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/lisp-to-dylan",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/lo/gg/logging
+++ b/v1/lo/gg/logging
@@ -1,0 +1,33 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Logging library",
+  "keywords": [],
+  "name": "logging",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/logging",
+                 "version": "1.0.0"
+               }, {
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/logging",
+                 "version": "1.0.1"
+               }, {
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/logging",
+                 "version": "2.0.0"
+               }, {
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/logging",
+                 "version": "2.0.1"
+               }, {
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/logging",
+                 "version": "2.1.0"
+               }]
+}

--- a/v1/ls/p-/lsp-dylan
+++ b/v1/ls/p-/lsp-dylan
@@ -1,0 +1,14 @@
+{
+  "category": "development tools",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Language Server Protocol",
+  "keywords": ["lsp"],
+  "name": "lsp-dylan",
+  "releases": [{
+                 "deps": ["command-line-parser@3.0", "json@1.0", "pacman@0.2",
+                          "uncommon-dylan@0.2", "workspaces@0.2"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/lsp-dylan",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/me/la/melange
+++ b/v1/me/la/melange
@@ -1,0 +1,13 @@
+{
+  "category": "development tools",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "C-FFI interface generator for Open Dylan",
+  "keywords": [],
+  "name": "melange",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/melange",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/me/ta/meta
+++ b/v1/me/ta/meta
@@ -1,0 +1,13 @@
+{
+  "category": "development tools",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Recursive descent parser DSL",
+  "keywords": [],
+  "name": "meta",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/meta",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/mi/me/mime
+++ b/v1/mi/me/mime
@@ -1,0 +1,13 @@
+{
+  "category": "network",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "MIME type map",
+  "keywords": [],
+  "name": "mime",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/mime",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/op/en/opendylan
+++ b/v1/op/en/opendylan
@@ -1,0 +1,23 @@
+{
+  "category": "compilers",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Dylan compiler, IDE, and related libraries",
+  "keywords": [],
+  "name": "opendylan",
+  "releases": [{
+                 "deps": [],
+                 "license": "DUAL",
+                 "url": "https://github.com/dylan-lang/opendylan",
+                 "version": "2014.1.0"
+               }, {
+                 "deps": [],
+                 "license": "DUAL",
+                 "url": "https://github.com/dylan-lang/opendylan",
+                 "version": "2019.1.0"
+               }, {
+                 "deps": [],
+                 "license": "DUAL",
+                 "url": "https://github.com/dylan-lang/opendylan",
+                 "version": "2020.1.0"
+               }]
+}

--- a/v1/pa/cm/pacman
+++ b/v1/pa/cm/pacman
@@ -1,0 +1,26 @@
+{
+  "category": "development tools",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Dylan package manager -- search for, download, and install available Dylan software packages.",
+  "keywords": ["package"],
+  "name": "pacman",
+  "releases": [{
+                 "deps": ["json@1.0", "regular-expressions@1.0",
+                          "testworks@1.1", "uncommon-dylan@0.2"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/pacman",
+                 "version": "0.0.2"
+               }, {
+                 "deps": ["json@1.0", "logging@2.0", "regular-expressions@1.0",
+                          "testworks@2.0", "uncommon-dylan@0.2"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/pacman",
+                 "version": "0.2.0"
+               }, {
+                 "deps": ["json@1.0", "logging@2.1", "regular-expressions@1.0",
+                          "testworks@2.0", "uncommon-dylan@0.2"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/pacman",
+                 "version": "0.3.0"
+               }]
+}

--- a/v1/pa/cm/pacman-catalog
+++ b/v1/pa/cm/pacman-catalog
@@ -1,0 +1,18 @@
+{
+  "category": "development tools",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Dylan package manager catalog -- descriptors for all known Dylan packages.",
+  "keywords": ["package"],
+  "name": "pacman-catalog",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/pacman-catalog",
+                 "version": "0.1.0"
+               }, {
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/pacman-catalog",
+                 "version": "0.2.1"
+               }]
+}

--- a/v1/pe/g-/peg-parser
+++ b/v1/pe/g-/peg-parser
@@ -1,0 +1,13 @@
+{
+  "category": "development tools",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "recursive descent parser that handles attributed parsing expression grammars (PEGs)",
+  "keywords": [],
+  "name": "peg-parser",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/peg-parser",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/pr/io/priority-queue
+++ b/v1/pr/io/priority-queue
@@ -1,0 +1,13 @@
+{
+  "category": "data structures",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Priority queue data structure",
+  "keywords": [],
+  "name": "priority-queue",
+  "releases": [{
+                 "deps": [],
+                 "license": "LGPL",
+                 "url": "https://github.com/dylan-lang/priority-queue",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/re/gu/regular-expressions
+++ b/v1/re/gu/regular-expressions
@@ -1,0 +1,13 @@
+{
+  "category": "parsers",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Regular expressions",
+  "keywords": ["regex", "regexp"],
+  "name": "regular-expressions",
+  "releases": [{
+                 "deps": ["strings"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/regular-expressions",
+                 "version": "1.0.0"
+               }]
+}

--- a/v1/se/qu/sequence-stream
+++ b/v1/se/qu/sequence-stream
@@ -1,0 +1,13 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "A replacement for the normal <sequence-stream> classes",
+  "keywords": [],
+  "name": "sequence-stream",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/sequence-stream",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/se/ri/serialization
+++ b/v1/se/ri/serialization
@@ -1,0 +1,13 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Serialize Dylan objects to various formats",
+  "keywords": ["json", "marshal"],
+  "name": "serialization",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-foundry/serialization",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/sh/oo/shootout
+++ b/v1/sh/oo/shootout
@@ -1,0 +1,13 @@
+{
+  "category": "examples",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Dylan solutions to the great programming language shootout",
+  "keywords": [],
+  "name": "shootout",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/shootout",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/sk/ip/skip-list
+++ b/v1/sk/ip/skip-list
@@ -1,0 +1,13 @@
+{
+  "category": "data structures",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Skip list collection library",
+  "keywords": [],
+  "name": "skip-list",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/skip-list",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/sl/ot/slot-visitor
+++ b/v1/sl/ot/slot-visitor
@@ -1,0 +1,13 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Define a visitor function to recursively visit and alter objects and",
+  "keywords": [],
+  "name": "slot-visitor",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/slot-visitor",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/sp/hi/sphinx-extensions
+++ b/v1/sp/hi/sphinx-extensions
@@ -1,0 +1,13 @@
+{
+  "category": "documentation",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Extensions to Sphinx for the Open Dylan website and documentation",
+  "keywords": [],
+  "name": "sphinx-extensions",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/sphinx-extensions",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/st/ri/strings
+++ b/v1/st/ri/strings
@@ -1,0 +1,18 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "String manipulation",
+  "keywords": [],
+  "name": "strings",
+  "releases": [{
+                 "deps": [],
+                 "license": "",
+                 "url": "https://github.com/dylan-lang/strings",
+                 "version": "1.0.0"
+               }, {
+                 "deps": [],
+                 "license": "",
+                 "url": "https://github.com/dylan-lang/strings",
+                 "version": "1.1.0"
+               }]
+}

--- a/v1/te/st/testworks
+++ b/v1/te/st/testworks
@@ -1,0 +1,23 @@
+{
+  "category": "testing",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Unit testing framework",
+  "keywords": [],
+  "name": "testworks",
+  "releases": [{
+                 "deps": ["command-line-parser"],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/testworks",
+                 "version": "1.0.0"
+               }, {
+                 "deps": ["command-line-parser@3.0"],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/testworks",
+                 "version": "1.1.0"
+               }, {
+                 "deps": ["command-line-parser@3.0"],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/testworks",
+                 "version": "2.0.0"
+               }]
+}

--- a/v1/un/co/uncommon-dylan
+++ b/v1/un/co/uncommon-dylan
@@ -1,0 +1,18 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "uncommon-utils library provides utilities of extremely general nature that could potentially be candidates for moving to the common-dylan library at some point. Also provides the uncommon-dylan package, which shortens some of the names in the Dylan package, for example <integer> -> <int>.",
+  "keywords": [],
+  "name": "uncommon-dylan",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/cgay/uncommon-dylan",
+                 "version": "0.1.0"
+               }, {
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/cgay/uncommon-dylan",
+                 "version": "0.2.0"
+               }]
+}

--- a/v1/ur/i/uri
+++ b/v1/ur/i/uri
@@ -1,0 +1,13 @@
+{
+  "category": "network",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "URI library",
+  "keywords": [],
+  "name": "uri",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/uri",
+                 "version": "1.0.0"
+               }]
+}

--- a/v1/uu/id/uuid
+++ b/v1/uu/id/uuid
@@ -1,0 +1,13 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Universally unique identifiers",
+  "keywords": [],
+  "name": "uuid",
+  "releases": [{
+                 "deps": [],
+                 "license": "None",
+                 "url": "https://github.com/dylan-foundry/uuid",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/vs/co/vscode-dylan
+++ b/v1/vs/co/vscode-dylan
@@ -1,0 +1,13 @@
+{
+  "category": "editor support",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Dylan support for Visual Studio Code",
+  "keywords": [],
+  "name": "vscode-dylan",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/vscode-dylan",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/we/b-/web-framework
+++ b/v1/we/b-/web-framework
@@ -1,0 +1,13 @@
+{
+  "category": "utilities",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Web app utilities",
+  "keywords": [],
+  "name": "web-framework",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/web-framework",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/wo/rk/workspaces
+++ b/v1/wo/rk/workspaces
@@ -1,0 +1,22 @@
+{
+  "category": "development tools",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Manipulate Dylan development workspaces",
+  "keywords": [],
+  "name": "workspaces",
+  "releases": [{
+                 "deps": ["json@1.0", "logging@2.1", "pacman@0.2",
+                          "regular-expressions@1.0", "testworks@2.0",
+                          "uncommon-dylan@0.2"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/workspaces",
+                 "version": "0.2.0"
+               }, {
+                 "deps": ["json@1.0", "logging@2.1", "pacman@0.3",
+                          "regular-expressions@1.0", "testworks@2.0",
+                          "uncommon-dylan@0.2"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/workspaces",
+                 "version": "0.3.0"
+               }]
+}

--- a/v1/wr/ap/wrapper-streams
+++ b/v1/wr/ap/wrapper-streams
@@ -1,0 +1,13 @@
+{
+  "category": "io",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Wrapper streams",
+  "keywords": [],
+  "name": "wrapper-streams",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/wrapper-streams",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/xm/l-/xml-parser
+++ b/v1/xm/l-/xml-parser
@@ -1,0 +1,13 @@
+{
+  "category": "parsers",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "XML parser",
+  "keywords": [],
+  "name": "xml-parser",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/xml-parser",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/xm/l-/xml-rpc
+++ b/v1/xm/l-/xml-rpc
@@ -1,0 +1,13 @@
+{
+  "category": "network",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "XML-RPC server and client",
+  "keywords": [],
+  "name": "xml-rpc",
+  "releases": [{
+                 "deps": [],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-lang/xml-rpc",
+                 "version": "0.1.0"
+               }]
+}

--- a/v1/zl/ib/zlib
+++ b/v1/zl/ib/zlib
@@ -1,0 +1,13 @@
+{
+  "category": "compression",
+  "contact": "dylan-lang@googlegroups.com",
+  "description": "Simple Dylan zlib wrapper",
+  "keywords": [],
+  "name": "zlib",
+  "releases": [{
+                 "deps": [],
+                 "license": "unknown",
+                 "url": "https://github.com/dylan-lang/zlib",
+                 "version": "0.1.0"
+               }]
+}


### PR DESCRIPTION
This separates out the catalog into one file per package and a directory
structure that is more scalable. It also reduces the possibility of conflicts
when updating any given package.

For now the old catalog isn't deleted.

At the same time, some attributes are moved from `<package>` to `<release>`
since they can potentially change with each release.