### PR TITLE
Add testworks release 2.2.0

### DIFF
--- a/v1/te/st/testworks
+++ b/v1/te/st/testworks
@@ -1,12 +1,25 @@
 {
-  "category": "testing",
-  "contact": "dylan-lang@googlegroups.com",
+  "category": "",
+  "contact": "",
   "description": "Unit testing framework",
-  "keywords": [],
+  "keywords": ["testing"],
   "name": "testworks",
   "releases": [{
-                 "dependencies": ["command-line-parser@3.1.1", "json@1.0", "strings@1.1"],
-                 "deps": ["command-line-parser@3.1.1", "json@1.0", "strings@1.1"],
+                 "dependencies": ["command-line-parser@3.1.1", "json@1.0.0",
+                                  "strings@1.1.0"],
+                 "deps": ["command-line-parser@3.1.1", "json@1.0.0",
+                          "strings@1.1.0"],
+                 "dev-dependencies": [],
+                 "license": "Unknown",
+                 "url": "https://github.com/dylan-lang/testworks",
+                 "version": "2.2.0"
+               },
+               {
+                 "dependencies": ["command-line-parser@3.1.1", "json@1.0.0",
+                                  "strings@1.1.0"],
+                 "deps": ["command-line-parser@3.1.1", "json@1.0.0",
+                          "strings@1.1.0"],
+                 "dev-dependencies": [],
                  "license": "unknown",
                  "url": "https://github.com/dylan-lang/testworks",
                  "version": "2.1.0"
@@ -14,6 +27,7 @@
                {
                  "dependencies": ["command-line-parser@3.0.0"],
                  "deps": ["command-line-parser@3.0.0"],
+                 "dev-dependencies": [],
                  "license": "unknown",
                  "url": "https://github.com/dylan-lang/testworks",
                  "version": "2.0.0"
@@ -21,6 +35,7 @@
                {
                  "dependencies": ["command-line-parser@3.0.0"],
                  "deps": ["command-line-parser@3.0.0"],
+                 "dev-dependencies": [],
                  "license": "unknown",
                  "url": "https://github.com/dylan-lang/testworks",
                  "version": "1.1.0"
@@ -28,6 +43,7 @@
                {
                  "dependencies": ["command-line-parser"],
                  "deps": ["command-line-parser"],
+                 "dev-dependencies": [],
                  "license": "unknown",
                  "url": "https://github.com/dylan-lang/testworks",
                  "version": "1.0.0"


### PR DESCRIPTION
This release is primarily changes to the documentation so that it can be more easily integrated with the auto-generated library reference.