### PR TITLE
Add statistics@0.1.0

### DIFF
--- a/v1/st/at/statistics
+++ b/v1/st/at/statistics
@@ -1,0 +1,15 @@
+{
+  "category": "",
+  "contact": "",
+  "description": "A collection of data analysis libraries",
+  "keywords": ["data"],
+  "name": "statistics",
+  "releases": [{
+                 "dependencies": [],
+                 "deps": [],
+                 "dev-dependencies": ["testworks"],
+                 "license": "MIT",
+                 "url": "https://github.com/dylan-foundry/data-analysis",
+                 "version": "0.1.0"
+               }]
+}


### PR DESCRIPTION
I accidentally called the package "statistics" in the package file and I'm going with that for now as that's the only library actually implemented so far. We can always change it later if we want to.