### PR TITLE
Fix test suite

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,31 +11,30 @@ on:
   # This enables the Run Workflow button on the Actions tab.
   workflow_dispatch:
 
-# We use dylan-tool here so that the library will be tested with the package
-# deps specified in pkg.json.
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: dylan-lang/install-dylan-tool@v1
+      - name: Checkout pacman-catalog
+        uses: actions/checkout@v4
 
-      - name: Create workspace
-        run: |
-          ./dylan new workspace pc
-
-      - uses: actions/checkout@v2
-        with:
-          path: pc/pacman-catalog
+      - name: Install dylan-tool
+        uses: dylan-lang/install-dylan-tool@v3
 
       - name: Build pacman-catalog-test-suite
         run: |
-          cd pc
-          DYLAN_CATALOG=./pacman-catalog ../dylan update
-          ../dylan-compiler -build -jobs 3 pacman-catalog-test-suite
+          DYLAN_CATALOG=. dylan update
+          dylan build -a
 
       - name: Run pacman-catalog-test-suite
         run: |
-          cd pc
-          DYLAN_CATALOG=./pacman-catalog _build/bin/pacman-catalog-test-suite
+          DYLAN_CATALOG=. _build/bin/pacman-catalog-test-suite --report surefire --report-file _build/pacman-catalog-tests.xml
+
+      - name: Publish Test Report
+        if: success() || failure()
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: '**/_build/*-tests.xml'
+          detailed_summary: true
+          include_passed: true

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository is a set of package definitions for the Dylan programming
 language. This data is used by the
-[dylan-tool](https://github.com/dylan-lang/dylan-tool) library to install Dylan
-packages and their dependencies.
+[dylan](https://github.com/dylan-lang/dylan-tool) command-line tool to install
+Dylan packages and their dependencies.
 
 If you would like to add a new library to the catalog, or publish a new release
 of an existing package, see the [dylan

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -9,7 +9,7 @@
     "category": "development tools",
     "contact": "dylan-lang@googlegroups.com",
     "dev-dependencies": [
-        "dylan-tool@0.6",
-        "testworks@2.1"
+        "dylan-tool",
+        "testworks@3.2"
     ]
 }

--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -2,13 +2,15 @@ Module: dylan-user
 
 define library pacman-catalog-test-suite
   use common-dylan;
-  use dylan-tool-lib,
+  use dylan-tool,
     import: { pacman };
+  use system;
   use testworks;
 end;
 
 define module pacman-catalog-test-suite
   use common-dylan;
+  use locators;
   use pacman,
     import: { catalog, load-all-catalog-packages, validate-catalog };
   use testworks;

--- a/tests/test-suite.dylan
+++ b/tests/test-suite.dylan
@@ -1,7 +1,10 @@
 Module: pacman-catalog-test-suite
 
+
 define test test-validate-catalog ()
-  assert-no-errors(validate-catalog(catalog()));
+  let app-file = as(<file-locator>, application-filename());
+  let cat-dir = app-file.locator-directory.locator-directory.locator-directory;
+  assert-no-errors(validate-catalog(catalog(directory: cat-dir)));
   let packages = load-all-catalog-packages(catalog());
   test-output("loaded %d packages from catalog\n", packages.size);
   assert-true(packages.size > 0);


### PR DESCRIPTION
I missed the error when trying to publish `strings@2.0.0` even though I ran the test suite locally. This fixes that.